### PR TITLE
Implement MessageUnpacker#unpackAsJsonValue, and remove #unpackValue() and #unpackValue(Variable)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,10 @@ java {
 }
 
 dependencies {
+    compileOnly("org.embulk:embulk-spi:0.11")
+
+    testImplementation("org.embulk:embulk-spi:0.11")
+
     testImplementation("junit:junit:4.13.2")
 
     // For Scala-based tests came with msgpack-core embedded

--- a/src/test/java/org/embulk/util/msgpack/core/example/MessagePackExample.java
+++ b/src/test/java/org/embulk/util/msgpack/core/example/MessagePackExample.java
@@ -1,6 +1,7 @@
 /*
  * This file is based on a copy from MessagePack for Java v0.8.24 with modification on :
  * - moving its Java package to org.embulk.util.msgpack.value.example.
+ * - rewriting readAndWriteFile() with #unpackAsJsonValue()
  *
  * It is licensed under the Apache License, Version 2.0.
  */
@@ -22,6 +23,14 @@
 //
 package org.embulk.util.msgpack.core.example;
 
+import org.embulk.spi.json.JsonArray;
+import org.embulk.spi.json.JsonBoolean;
+import org.embulk.spi.json.JsonDouble;
+import org.embulk.spi.json.JsonLong;
+import org.embulk.spi.json.JsonNull;
+import org.embulk.spi.json.JsonObject;
+import org.embulk.spi.json.JsonString;
+import org.embulk.spi.json.JsonValue;
 import org.embulk.util.msgpack.core.MessagePack;
 import org.embulk.util.msgpack.core.MessagePack.PackerConfig;
 import org.embulk.util.msgpack.core.MessagePack.UnpackerConfig;
@@ -188,55 +197,46 @@ public class MessagePackExample
             MessageFormat format = unpacker.getNextFormat();
 
             // You can also use unpackValue to extract a value of any type
-            Value v = unpacker.unpackValue();
-            switch (v.getValueType()) {
-                case NIL:
-                    v.isNilValue(); // true
+            JsonValue v = unpacker.unpackAsJsonValue();
+            switch (v.getEntityType()) {
+                case NULL:
+                    v.isJsonNull(); // true
                     System.out.println("read nil");
                     break;
                 case BOOLEAN:
-                    boolean b = v.asBooleanValue().getBoolean();
+                    boolean b = v.asJsonBoolean().booleanValue();
                     System.out.println("read boolean: " + b);
                     break;
-                case INTEGER:
-                    IntegerValue iv = v.asIntegerValue();
-                    if (iv.isInIntRange()) {
-                        int i = iv.toInt();
+                case LONG:
+                    JsonLong iv = v.asJsonLong();
+                    if (iv.isIntValue()) {
+                        int i = iv.intValue();
                         System.out.println("read int: " + i);
                     }
-                    else if (iv.isInLongRange()) {
-                        long l = iv.toLong();
+                    else if (iv.isLongValue()) {
+                        long l = iv.longValue();
                         System.out.println("read long: " + l);
                     }
                     else {
-                        BigInteger i = iv.toBigInteger();
+                        BigInteger i = iv.bigIntegerValue();
                         System.out.println("read long: " + i);
                     }
                     break;
-                case FLOAT:
-                    FloatValue fv = v.asFloatValue();
-                    float f = fv.toFloat();   // use as float
-                    double d = fv.toDouble(); // use as double
+                case DOUBLE:
+                    JsonDouble fv = v.asJsonDouble();
+                    float f = fv.floatValue();   // use as float
+                    double d = fv.doubleValue(); // use as double
                     System.out.println("read float: " + d);
                     break;
                 case STRING:
-                    String s = v.asStringValue().asString();
+                    String s = v.asJsonString().getString();
                     System.out.println("read string: " + s);
                     break;
-                case BINARY:
-                    byte[] mb = v.asBinaryValue().asByteArray();
-                    System.out.println("read binary: size=" + mb.length);
-                    break;
                 case ARRAY:
-                    ArrayValue a = v.asArrayValue();
-                    for (Value e : a) {
+                    JsonArray a = v.asJsonArray();
+                    for (JsonValue e : a) {
                         System.out.println("read array element: " + e);
                     }
-                    break;
-                case EXTENSION:
-                    ExtensionValue ev = v.asExtensionValue();
-                    byte extType = ev.getType();
-                    byte[] extValue = ev.getData();
                     break;
             }
         }

--- a/src/test/scala/org/embulk/util/msgpack/core/MessagePackTest.scala
+++ b/src/test/scala/org/embulk/util/msgpack/core/MessagePackTest.scala
@@ -1,6 +1,7 @@
 /*
  * This file is based on a copy from MessagePack for Java v0.8.24 with modification on :
  * - moving its Java package to org.embulk.util.msgpack.core.
+ * - removing a test "MessagePack" should "pack/unpack maps in lists"
  *
  * It is licensed under the Apache License, Version 2.0.
  */
@@ -551,43 +552,6 @@ class MessagePackTest extends MessagePackSpec {
         check(ext, _.packExtensionTypeHeader(ext.getType, ext.getLength), _.unpackExtensionTypeHeader())
       }
 
-    }
-
-    "pack/unpack maps in lists" in {
-      val aMap = List(Map("f" -> "x"))
-
-      check(
-        aMap, { packer =>
-          packer.packArrayHeader(aMap.size)
-          for (m <- aMap) {
-            packer.packMapHeader(m.size)
-            for ((k, v) <- m) {
-              packer.packString(k)
-              packer.packString(v)
-            }
-          }
-        }, { unpacker =>
-          val v = new Variable()
-          unpacker.unpackValue(v)
-          import scala.collection.JavaConverters._
-          v.asArrayValue().asScala
-            .map { m =>
-              val mv  = m.asMapValue()
-              val kvs = mv.getKeyValueArray
-
-              kvs
-                .grouped(2)
-                .map({ kvp: Array[Value] =>
-                  val k = kvp(0)
-                  val v = kvp(1)
-
-                  (k.asStringValue().asString, v.asStringValue().asString)
-                })
-                .toMap
-            }
-            .toList
-        }
-      )
     }
 
   }

--- a/src/test/scala/org/embulk/util/msgpack/core/MessageUnpackerTest.scala
+++ b/src/test/scala/org/embulk/util/msgpack/core/MessageUnpackerTest.scala
@@ -1,6 +1,7 @@
 /*
  * This file is based on a copy from MessagePack for Java v0.8.24 with modification on :
  * - moving its Java package to org.embulk.util.msgpack.core.
+ * - rewriting readTest to use #unpackAsJsonValue()
  *
  * It is licensed under the Apache License, Version 2.0.
  */
@@ -912,7 +913,7 @@ class MessageUnpackerTest extends MessagePackSpec {
     def readTest(input: MessageBufferInput): Unit = {
       withResource(MessagePack.newDefaultUnpacker(input)) { unpacker =>
         while (unpacker.hasNext) {
-          unpacker.unpackValue()
+          unpacker.unpackAsJsonValue()
         }
       }
     }

--- a/src/test/scala/org/embulk/util/msgpack/value/ValueTest.scala
+++ b/src/test/scala/org/embulk/util/msgpack/value/ValueTest.scala
@@ -1,6 +1,8 @@
 /*
  * This file is based on a copy from MessagePack for Java v0.8.24 with modification on :
  * - moving its Java package to org.embulk.util.msgpack.value.
+ * - removing a test "Value" should "tell most succinct integer type"
+ * - removing checkSuccinctType()
  *
  * It is licensed under the Apache License, Version 2.0.
  */
@@ -29,47 +31,7 @@ import org.scalacheck.Prop.{forAll, propBoolean}
 import scala.util.parsing.json.JSON
 
 class ValueTest extends MessagePackSpec {
-  def checkSuccinctType(pack: MessagePacker => Unit, expectedAtMost: MessageFormat): Boolean = {
-    val b  = createMessagePackData(pack)
-    val v1 = MessagePack.newDefaultUnpacker(b).unpackValue()
-    val mf = v1.asIntegerValue().mostSuccinctMessageFormat()
-    mf.getValueType shouldBe ValueType.INTEGER
-    mf.ordinal() shouldBe <=(expectedAtMost.ordinal())
-
-    val v2 = new Variable
-    MessagePack.newDefaultUnpacker(b).unpackValue(v2)
-    val mf2 = v2.asIntegerValue().mostSuccinctMessageFormat()
-    mf2.getValueType shouldBe ValueType.INTEGER
-    mf2.ordinal() shouldBe <=(expectedAtMost.ordinal())
-
-    true
-  }
-
   "Value" should {
-    "tell most succinct integer type" in {
-      forAll { (v: Byte) =>
-        checkSuccinctType(_.packByte(v), MessageFormat.INT8)
-      }
-      forAll { (v: Short) =>
-        checkSuccinctType(_.packShort(v), MessageFormat.INT16)
-      }
-      forAll { (v: Int) =>
-        checkSuccinctType(_.packInt(v), MessageFormat.INT32)
-      }
-      forAll { (v: Long) =>
-        checkSuccinctType(_.packLong(v), MessageFormat.INT64)
-      }
-      forAll { (v: Long) =>
-        checkSuccinctType(_.packBigInteger(BigInteger.valueOf(v)), MessageFormat.INT64)
-      }
-      forAll { (v: Long) =>
-        v > 0 ==> {
-          // Create value between 2^63-1 < v <= 2^64-1
-          checkSuccinctType(_.packBigInteger(BigInteger.valueOf(Long.MaxValue).add(BigInteger.valueOf(v))), MessageFormat.UINT64)
-        }
-      }
-    }
-
     "produce json strings" in {
 
       import ValueFactory._


### PR DESCRIPTION
This library intends to be used from [`embulk-parser-msgpack`](https://github.com/embulk/embulk-parser-msgpack) to parse into `JsonValue`.

To realize it, this pull request implements `MessageUnpacker#unpackAsJsonValue` instead of `MessageUnpacker#unpackValue`.

Note that it'll be a tentative implementation as the first quick step. We plan to have an independent class eventually, and to make `msgpack-core`-based classes invisible.