### PR TITLE
Add a note about future compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 embulk-util-msgpack
 ====================
 
+*NOTE: No future compatibility is guaranteed as of v0.8.24. All classes in this library may go away.*
+
 This is a utility with the MessagePack format.
 
 It started from a fork of [MessagePack for Java (`msgpack-java`)](https://github.com/msgpack/msgpack-java) so that it would not depend on `msgpack-java`. Plugin's `msgpack-java` could conflict because the Embulk SPI has had a dependency on `msgpack-java` by itself.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,7 @@ tasks.javadoc {
     options {
         locale = "en_US"
         encoding = "UTF-8"
+        overview = "src/main/html/overview.html"
         (this as StandardJavadocDocletOptions).apply {
             links("https://docs.oracle.com/javase/8/docs/api/")
         }

--- a/src/main/html/overview.html
+++ b/src/main/html/overview.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Utility with the MessagePack format for Embulk plugins</title>
+  </head>
+  <body>
+    <p>Utility with the MessagePack format for Embulk plugins.</p>
+    <p>NOTE: No future compatibility is guaranteed as of v0.8.24. All classes in this library may go away.</p>
+  </body>
+</html>


### PR DESCRIPTION
The first version `0.8.24` is a quick step, and we do not guarantee any compatibility. This pull request adds an explicit note about that.