### PR TITLE
Suppress Javadoc errors

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,4 +17,4 @@ jobs:
         distribution: "temurin"
         cache: "gradle"
     - name: Check
-      run: ./gradlew check
+      run: ./gradlew check javadoc

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,11 @@ tasks.javadoc {
         overview = "src/main/html/overview.html"
         (this as StandardJavadocDocletOptions).apply {
             links("https://docs.oracle.com/javase/8/docs/api/")
+
+            // TODO: Remove those options.
+            // They are added to suppress javadoc errors from the original msgpack-java.
+            addBooleanOption("Xdoclint:none", true)
+            addStringOption("Xmaxwarns", "1")
         }
     }
 }


### PR DESCRIPTION
A try to release has failed due to Javadoc errors from the original msgpack-java. This pull request is to suppress those errors.